### PR TITLE
Ci/publish ghpage

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches: [main]
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish-gh-pages:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup node environment (for building)
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.19
+          cache: yarn
+
+      - name: Fetch dependencies
+        run: |
+          yarn --frozen-lockfile
+
+      - name: Build website
+        run: |
+          yarn build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.OPS_TOKEN }}
+          publish_dir: ./out
+          cname: axone.xyz

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+    output: 'export',
+};
 
 export default nextConfig;


### PR DESCRIPTION
This PR therefore introduces the workflow for publishing the `main` branch to GitHub Pages. Indeed, the project enables a static build of the website. Therefore, initially, deploying to GitHub Pages seems more suitable and faster, as we do with our other websites. 

_Notes:_
- Once the release workflow is implemented, we will switch to this workflow to deploy releases only.
- The flexibility offered by [Vercel](https://vercel.com/dashboard) should still be considered, especially because it allows for the possibility of multiple deployment environments (features, integration, production), which cannot be managed with GitHub Pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced automation with a "Publish" workflow for manual website deployment to GitHub Pages.
- **Refactor**
	- Optimized website build configuration for better deployment efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->