### PR TITLE
ci(workflow): configure gh_pages environment and Matomo vars

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,10 @@ concurrency:
 jobs:
   publish-gh-pages:
     runs-on: ubuntu-22.04
+    environment: github-pages
+    env:
+      NEXT_PUBLIC_MATOMO_URL: ${{ vars.MATOMO_URL }}
+      NEXT_PUBLIC_MATOMO_SITE_ID: ${{ vars.MATOMO_SITE_ID }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Ah, I mistakenly thought the deployment was done by Vercel 😅, but it's actually hosted on GitHub Pages. So this PR configure the `github-pages` environment in the CI for website deployment with [Matomo](https://matomo.org/) settings, as per PR #55.

From what I've been able to test, it works.

![image](https://github.com/axone-protocol/website/assets/9574336/f67791a1-d2e0-4098-bd9e-39cc5f07f027)
